### PR TITLE
[BUG] 🐛 Fix: Allow editing zones without Power/Energy sensors

### DIFF
--- a/custom_components/home_performance/config_flow.py
+++ b/custom_components/home_performance/config_flow.py
@@ -264,27 +264,39 @@ class HomePerformanceOptionsFlow(config_entries.OptionsFlow):
                 )
             )
 
-        # Power sensor - EntitySelector handles None gracefully
-        schema_dict[vol.Optional(
-            CONF_POWER_SENSOR,
-            default=current.get(CONF_POWER_SENSOR),
-        )] = selector.EntitySelector(
-            selector.EntitySelectorConfig(
-                domain="sensor",
-                device_class="power",
+        # Power sensor - only set default if value exists (EntitySelector may not handle None in all HA versions)
+        power_sensor_value = current.get(CONF_POWER_SENSOR)
+        if power_sensor_value is not None:
+            schema_dict[vol.Optional(CONF_POWER_SENSOR, default=power_sensor_value)] = selector.EntitySelector(
+                selector.EntitySelectorConfig(
+                    domain="sensor",
+                    device_class="power",
+                )
             )
-        )
+        else:
+            schema_dict[vol.Optional(CONF_POWER_SENSOR)] = selector.EntitySelector(
+                selector.EntitySelectorConfig(
+                    domain="sensor",
+                    device_class="power",
+                )
+            )
 
-        # Energy sensor - EntitySelector handles None gracefully
-        schema_dict[vol.Optional(
-            CONF_ENERGY_SENSOR,
-            default=current.get(CONF_ENERGY_SENSOR),
-        )] = selector.EntitySelector(
-            selector.EntitySelectorConfig(
-                domain="sensor",
-                device_class="energy",
+        # Energy sensor - only set default if value exists
+        energy_sensor_value = current.get(CONF_ENERGY_SENSOR)
+        if energy_sensor_value is not None:
+            schema_dict[vol.Optional(CONF_ENERGY_SENSOR, default=energy_sensor_value)] = selector.EntitySelector(
+                selector.EntitySelectorConfig(
+                    domain="sensor",
+                    device_class="energy",
+                )
             )
-        )
+        else:
+            schema_dict[vol.Optional(CONF_ENERGY_SENSOR)] = selector.EntitySelector(
+                selector.EntitySelectorConfig(
+                    domain="sensor",
+                    device_class="energy",
+                )
+            )
 
         return self.async_show_form(
             step_id="init",


### PR DESCRIPTION
### Description

Fixes #30

This PR fixes a bug where users couldn't edit zone settings if they hadn't configured Power/Energy sensors during initial setup.

### Problem

When a zone was initially configured **without** a Power Sensor or External Energy Meter, attempting to edit it from the integration dashboard would fail — the form wouldn't save without providing both sensors, even though they are optional.

### Root Cause

In `config_flow.py`, the `HomePerformanceOptionsFlow` class was using:

default=current.get(CONF_POWER_SENSOR)  # Returns None if not configuredThe `EntitySelector` doesn't handle `None` as a default value gracefully in all Home Assistant versions, causing the form to require these optional fields.

### Solution

Applied the same conditional pattern already used for Surface/Volume fields to the Power/Energy sensor fields:

# Before (problematic)
schema_dict[vol.Optional(CONF_POWER_SENSOR, default=current.get(CONF_POWER_SENSOR))] = ...

# After (fixed)
power_sensor_value = current.get(CONF_POWER_SENSOR)
if power_sensor_value is not None:
    schema_dict[vol.Optional(CONF_POWER_SENSOR, default=power_sensor_value)] = ...
else:
    schema_dict[vol.Optional(CONF_POWER_SENSOR)] = ...### Testing

- [x] Create a zone without Power/Energy sensors
- [x] Edit the zone from integration options
- [x] Verify save works without requiring Power/Energy sensors
- [x] Verify existing zones with Power/Energy sensors still work correctly

### Files Changed

- `custom_components/home_performance/config_flow.py`