### PR TITLE
Add average_dt_24h to fix missing card temps

### DIFF
--- a/custom_components/home_performance/www/home-performance-card.js
+++ b/custom_components/home_performance/www/home-performance-card.js
@@ -256,7 +256,7 @@ class HomePerformanceCard extends LitElement {
     "energie_24h_estimee": ["energie_24h_estimee", "estimated_daily_energy", "daily_estimated_energy"],
     "temps_de_chauffe_24h": ["temps_de_chauffe_24h", "heating_time_24h", "daily_heating_time"],
     "ratio_de_chauffe": ["ratio_de_chauffe", "heating_ratio"],
-    "dt_moyen_24h": ["dt_moyen_24h", "average_delta_t", "avg_delta_t_24h"],
+    "dt_moyen_24h": ["dt_moyen_24h", "average_delta_t", "avg_delta_t_24h", "average_dt_24h"],
     "progression_analyse": ["progression_analyse", "analysis_progress"],
     "temps_restant_analyse": ["temps_restant_analyse", "analysis_time_remaining"],
   };


### PR DESCRIPTION
📝 Description

Adding average_dt_24h to fix the missing lovelace card temps in some configurations

🔗 Related Issue

Fixes #51 

🔄 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation
- [ ] 🔧 Refactoring
- [ ] ⚡ Performance

✅ Checklist

- [x] I have tested my changes locally
- [ ] I have updated documentation if necessary
- [x] My code follows the project style
- [ ] I have added logs if relevant